### PR TITLE
docs: Add web application section and fix Markdown formatting issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The objective of this project is not to curate a list of the most recommended pu
 An interactive web application is now available to navigate the collection, perform semantic searches, and explore relationships between authors, papers, and keywords through graph visualizations. Paper metadata enrichment including abstracts, keywords, authors, journals, and publication links (sourced via external APIs) is also integrated
 
 Access the web application:
+
 [![Streamlit App](https://img.shields.io/badge/Streamlit-Open_App-brightgreen?logo=streamlit)](https://quantum-tech-papers.streamlit.app/)
 
 Re-curring topics on this list include:

--- a/README.md
+++ b/README.md
@@ -9,18 +9,27 @@ app_file: main.py
 pinned: false
 ---
 # Quantum-tech-papers
-This repository contains a list of some of the papers and publications, I have read through my journey through quantum. 
+
+This repository contains a list of some of the papers and publications, I have read through my journey through quantum.
+
 I began working on this project through my undergraduate years and currently continue mantaining it in grad school.
+
 The objective of this project is not to curate a list of the most recommended publications for a beginner in quantum tech, but rather to build a journal (of sorts) that depics my journey through quantum publications. The full list of reads can be found here, but other branches include year by year breakdowns. The topics presented in this compilation often reflect my work and surges in interest through my time in this industry.
 
+An interactive web application is now available to navigate the collection, perform semantic searches, and explore relationships between authors, papers, and keywords through graph visualizations. Paper metadata enrichment including abstracts, keywords, authors, journals, and publication links (sourced via external APIs) is also integrated
+
+Access the web application:
+[![Streamlit App](https://img.shields.io/badge/Streamlit-Open_App-brightgreen?logo=streamlit)](https://quantum-tech-papers.streamlit.app/)
+
 Re-curring topics on this list include:
+
 - Quantum protocol design
 - Quantum algorithms
 - The Quantum internet
 - Silicon based quantum technologies
 - Ion traps
 - The Hong-Ou-Mandel effect
-- Quantum circuits 
+- Quantum circuits
 - Programmable quantum gates
 - Quantum error correction
 - Quantum error mitigation


### PR DESCRIPTION
- Added a section to the README introducing the interactive web application, which allows users to navigate the paper collection, perform semantic searches, and visualize relationships between authors, papers, and keywords through graph representations.  
- Mentioned the paper metadata enrichment process, which adds abstracts, keywords, authors, journals, and publication links through external APIs.  
- Inserted a Streamlit badge with a link to access the deployed web application.  
- Fixed **MD009/no-trailing-spaces**: Removed trailing spaces from the README.  
- Fixed **MD032/blanks-around-lists**: Ensured proper spacing before and after lists according to Markdown style guidelines.

No functional changes to the underlying data processing or application logic have been made. This PR strictly improves project documentation.